### PR TITLE
Copy recipes from climatology-research repo

### DIFF
--- a/async/bld.bat
+++ b/async/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/async/build.sh
+++ b/async/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/async/meta.yaml
+++ b/async/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: async
+  version: !!str 0.6.1
+
+source:
+  fn: async-0.6.1.tar.gz
+  url: https://pypi.python.org/packages/source/a/async/async-0.6.1.tar.gz
+  md5: 6f0e2ced1fe85f8410b9bde11be08587
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - async = async:main
+    #
+    # Would create an entry point called async that calls async.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - async
+    - async.mod
+    - async.test
+    - async.test.mod
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/gitpython-developers/async
+  license: New BSD License
+  summary: 'Async Framework'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/boto/bld.bat
+++ b/boto/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/boto/build.sh
+++ b/boto/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/boto/meta.yaml
+++ b/boto/meta.yaml
@@ -1,0 +1,111 @@
+package:
+  name: boto
+  version: !!str 2.28.0
+
+source:
+  fn: boto-2.28.0.tar.gz
+  url: https://pypi.python.org/packages/source/b/boto/boto-2.28.0.tar.gz
+  md5: 84ec31503b03a3a5dd049c7120cda845
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - boto = boto:main
+    #
+    # Would create an entry point called boto that calls boto.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - boto
+    - boto.beanstalk
+    - boto.cacerts
+    - boto.cloudformation
+    - boto.cloudfront
+    - boto.cloudsearch
+    - boto.cloudsearch2
+    - boto.cloudtrail
+    - boto.contrib
+    - boto.datapipeline
+    - boto.directconnect
+    - boto.dynamodb
+    - boto.dynamodb2
+    - boto.ec2
+    - boto.ec2.autoscale
+    - boto.ec2.cloudwatch
+    - boto.ec2.elb
+    - boto.ecs
+    - boto.elasticache
+    - boto.elastictranscoder
+    - boto.emr
+    - boto.file
+    - boto.fps
+    - boto.glacier
+    - boto.gs
+    - boto.iam
+    - boto.kinesis
+    - boto.manage
+    - boto.mashups
+    - boto.mturk
+    - boto.mws
+    - boto.opsworks
+    - boto.pyami
+    - boto.pyami.installers
+    - boto.pyami.installers.ubuntu
+    - boto.rds
+    - boto.rds2
+    - boto.redshift
+    - boto.roboto
+    - boto.route53
+    - boto.s3
+    - boto.sdb
+    - boto.sdb.db
+    - boto.sdb.db.manager
+    - boto.services
+    - boto.ses
+    - boto.sns
+    - boto.sqs
+    - boto.sts
+    - boto.support
+    - boto.swf
+    - boto.vpc
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/boto/boto/
+  license: MIT License
+  summary: 'Amazon Web Services Library'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/bottleneck/bld.bat
+++ b/bottleneck/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/bottleneck/build.sh
+++ b/bottleneck/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/bottleneck/meta.yaml
+++ b/bottleneck/meta.yaml
@@ -1,0 +1,64 @@
+package:
+  name: bottleneck
+  version: !!str 0.8.0
+
+source:
+  fn: Bottleneck-0.8.0.tar.gz
+  url: https://pypi.python.org/packages/source/B/Bottleneck/Bottleneck-0.8.0.tar.gz
+  md5: 1a363fa35ce521eebb838e1bd6520e24
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - bottleneck = bottleneck:main
+    #
+    # Would create an entry point called bottleneck that calls bottleneck.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy >=1.8
+
+  run:
+    - python
+    - numpy >=1.8
+
+test:
+  # Python imports
+  requires:
+    - nose
+  imports:
+    - bottleneck
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://berkeleyanalytics.com/bottleneck
+  license: BSD License
+  summary: 'Fast NumPy array functions written in Cython'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/bottleneck/run_test.py
+++ b/bottleneck/run_test.py
@@ -1,0 +1,2 @@
+import bottleneck
+bottleneck.test()

--- a/brewer2mpl/bld.bat
+++ b/brewer2mpl/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/brewer2mpl/build.sh
+++ b/brewer2mpl/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/brewer2mpl/meta.yaml
+++ b/brewer2mpl/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: brewer2mpl
+  version: !!str 1.4
+
+source:
+  fn: brewer2mpl-1.4.tar.gz
+  url: https://pypi.python.org/packages/source/b/brewer2mpl/brewer2mpl-1.4.tar.gz
+  md5: 49b7f7de78a5a47021aee91bee543026
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - brewer2mpl = brewer2mpl:main
+    #
+    # Would create an entry point called brewer2mpl that calls brewer2mpl.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - brewer2mpl
+    - brewer2mpl.wesanderson
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/jiffyclub/brewer2mpl/wiki
+  license: MIT License
+  summary: 'Connect colorbrewer2.org color maps to Python and matplotlib'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/choldate/build.sh
+++ b/choldate/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/choldate/container.yml
+++ b/choldate/container.yml
@@ -1,0 +1,20 @@
+# This Tank file will verify that scikits.sparse installs correctly. (It
+# installs suitesparse in the container as needed.)
+#
+# Run via: sudo -E tank container.yml
+
+containers:
+  - lucid-ci
+
+script:
+  - "wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O /tmp/Miniconda-3.5.5-Linux-x86_64.sh"
+  - "bash /tmp/Miniconda-3.5.5-Linux-x86_64.sh -b"
+    # For some reason, we need to install the dependencies manually :(
+  - "~/miniconda/bin/conda create --yes -n test python setuptools numpy"
+    # Install the actuall package
+  - "~/miniconda/bin/conda install --yes -n test /tmp/choldate-0.1.0-np18py27_0.tar.bz2"
+    # Run the tests!
+  - "/bin/bash"
+
+copy_into:
+  - "~/miniconda/conda-bld/linux-64/choldate-0.1.0-np18py27_0.tar.bz2": /tmp/choldate-0.1.0-np18py27_0.tar.bz2

--- a/choldate/meta.yaml
+++ b/choldate/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: choldate
+  version: "0.1.0"
+
+source:
+  fn: choldate-9f7bf993863743aeb4d1ee1fdcf2eb8d813c8794.tar.gz
+  url: https://github.com/jcrudy/choldate/archive/9f7bf993863743aeb4d1ee1fdcf2eb8d813c8794.tar.gz
+  sha1: 7b856e6bdcd96e402bc716ff6fd26e0fa992421e
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  number: 0
+
+requirements:
+  build:
+    - python
+    - cython
+    - setuptools
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  # Python imports
+  imports:
+    - choldate
+
+about:
+  home: https://github.com/jcrudy/choldate
+  license:  Custom (redistribution permitted but disclaimer must be preserved)
+  summary: 'Somewhat fast updating and downdating of Cholesky factors in Python'

--- a/ddt/bld.bat
+++ b/ddt/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/ddt/build.sh
+++ b/ddt/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/ddt/meta.yaml
+++ b/ddt/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: ddt
+  version: !!str 0.8.0
+
+source:
+  fn: ddt-0.8.0.tar.gz
+  url: https://pypi.python.org/packages/source/d/ddt/ddt-0.8.0.tar.gz
+  md5: 8cb68430ab98fc65355c7934021cf1f4
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - ddt = ddt:main
+    #
+    # Would create an entry point called ddt that calls ddt.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - ddt
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/txels/ddt
+  license: GNU Library or Lesser General Public License (LGPL)
+  summary: 'Data-Driven/Decorated Tests'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/dill/bld.bat
+++ b/dill/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/dill/build.sh
+++ b/dill/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/dill/meta.yaml
+++ b/dill/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: dill
+  version: !!str 0.2.1
+
+source:
+  fn: dill-0.2.1.tgz
+  url: https://pypi.python.org/packages/source/d/dill/dill-0.2.1.tgz
+  md5: 66f4d8fff8724568bde03e421bf520bb
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - dill = dill:main
+    #
+    # Would create an entry point called dill that calls dill.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - dill
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://www.cacr.caltech.edu/~mmckerns/dill.htm
+  license: 3-clause BSD
+  summary: 'serialize all of python (almost)'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/emcee/build.sh
+++ b/emcee/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/emcee/meta.yaml
+++ b/emcee/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: emcee
+  version: "2.1.0"
+
+source:
+  fn: emcee-2.1.0.tar.gz
+  url: https://pypi.python.org/packages/source/e/emcee/emcee-2.1.0.tar.gz
+  md5: c6b6fad05c824d40671d4a4fc58dfff7
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  # Python imports
+  imports:
+    - emcee
+
+  commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+    - "python -c 'import emcee; emcee.test()'"
+
+about:
+  home: http://dan.iel.fm/emcee/
+  license:  MIT License
+  summary: 'Kick ass affine-invariant ensemble MCMC sampling'

--- a/geopy/bld.bat
+++ b/geopy/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/geopy/build.sh
+++ b/geopy/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/geopy/meta.yaml
+++ b/geopy/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: geopy
+  version: !!str 0.99
+
+source:
+  fn: geopy-0.99.tar.gz
+  url: https://pypi.python.org/packages/source/g/geopy/geopy-0.99.tar.gz
+  md5: 4948be78aeb7809314a1c7454b5d6145
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - geopy = geopy:main
+    #
+    # Would create an entry point called geopy that calls geopy.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - geopy
+    - geopy.geocoders
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/geopy/geopy
+  license: MIT License
+  summary: 'Python Geocoding Toolbox'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/gitdb/bld.bat
+++ b/gitdb/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/gitdb/build.sh
+++ b/gitdb/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/gitdb/meta.yaml
+++ b/gitdb/meta.yaml
@@ -1,0 +1,64 @@
+package:
+  name: gitdb
+  version: !!str 0.5.4
+
+source:
+  fn: gitdb-0.5.4.tar.gz
+  url: https://pypi.python.org/packages/source/g/gitdb/gitdb-0.5.4.tar.gz
+  md5: 25353bb8d3ea527ba443dd88cd4e8a1c
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - gitdb = gitdb:main
+    #
+    # Would create an entry point called gitdb that calls gitdb.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - async >=0.6.1
+    - smmap >=0.8.0
+
+  run:
+    - python
+    - async >=0.6.1
+    - smmap >=0.8.0
+
+test:
+  # Python imports
+  imports:
+    - gitdb
+    - gitdb.db
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/gitpython-developers/gitdb
+  license: BSD License
+  summary: 'Git Object Database'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/gitpython/bld.bat
+++ b/gitpython/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/gitpython/build.sh
+++ b/gitpython/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/gitpython/meta.yaml
+++ b/gitpython/meta.yaml
@@ -1,0 +1,67 @@
+package:
+  name: gitpython
+  version: !!str 0.3.2.RC1
+
+source:
+  fn: GitPython-0.3.2.RC1.tar.gz
+  url: https://pypi.python.org/packages/source/G/GitPython/GitPython-0.3.2.RC1.tar.gz
+  md5: 849082fe29adc653a3621465213cab96
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - gitpython = gitpython:main
+    #
+    # Would create an entry point called gitpython that calls gitpython.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - gitdb >=0.5.1
+
+  run:
+    - python
+    - gitdb >=0.5.1
+
+test:
+  # Python imports
+  imports:
+    - git
+    - git.index
+    - git.objects
+    - git.objects.submodule
+    - git.refs
+    - git.repo
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://gitorious.org/projects/git-python/
+  license: BSD License
+  summary: 'Python Git Library'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/joblib/bld.bat
+++ b/joblib/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/joblib/build.sh
+++ b/joblib/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/joblib/meta.yaml
+++ b/joblib/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: joblib
+  version: !!str 0.8.0a3
+
+source:
+  fn: joblib-0.8.0a3.tar.gz
+  url: https://pypi.python.org/packages/source/j/joblib/joblib-0.8.0a3.tar.gz
+  md5: 93f7e8f765dc702a9611990500180416
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - joblib = joblib:main
+    #
+    # Would create an entry point called joblib that calls joblib.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - joblib
+    - joblib.test
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://packages.python.org/joblib/
+  license: BSD License
+  summary: 'Lightweight pipelining: using Python functions as pipeline jobs.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/pyproj/build.sh
+++ b/pyproj/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/pyproj/container.yml
+++ b/pyproj/container.yml
@@ -1,0 +1,16 @@
+# This Tank file will build pyproj inside the container.
+
+containers:
+  - lucid-ci
+
+script:
+  - "wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O /tmp/Miniconda-3.5.5-Linux-x86_64.sh"
+  - "bash /tmp/Miniconda-3.5.5-Linux-x86_64.sh -b"
+  - "~/miniconda/bin/conda install --yes conda-build"
+  - "~/miniconda/bin/conda build /tmp/pyproj"
+
+copy_into:
+  - "./": "/tmp/pyproj"
+
+copy_out:
+  - "miniconda/conda-bld/linux-64": "/tmp/built/"

--- a/pyproj/meta.yaml
+++ b/pyproj/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: pyproj
+  version: "1.9.3"
+
+source:
+  fn: pyproj-1.9.3.tar.gz
+  url: https://pypi.python.org/packages/source/p/pyproj/pyproj-1.9.3.tar.gz
+  md5: ad0ac0602b6373c4203b4d0774445694
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - pyproj
+
+about:
+  home: http://code.google.com/p/pyproj/
+  license: OSI Approved
+  summary: 'Python interface to PROJ.4 library'

--- a/pyshp/bld.bat
+++ b/pyshp/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/pyshp/build.sh
+++ b/pyshp/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/pyshp/meta.yaml
+++ b/pyshp/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: pyshp
+  version: !!str 1.2.1
+
+source:
+  fn: pyshp-1.2.1.tar.gz
+  url: https://pypi.python.org/packages/source/p/pyshp/pyshp-1.2.1.tar.gz
+  md5: 156654b3c7878c4a31d27e4b9dc34377
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pyshp = pyshp:main
+    #
+    # Would create an entry point called pyshp that calls pyshp.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - shapefile
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://code.google.com/p/pyshp
+  license: MIT
+  summary: 'Pure Python read/write support for ESRI Shapefile format'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/pystan/bld.bat
+++ b/pystan/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/pystan/build.sh
+++ b/pystan/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/pystan/meta.yaml
+++ b/pystan/meta.yaml
@@ -1,0 +1,64 @@
+package:
+  name: pystan
+  version: !!str 2.2.0.1
+
+source:
+  fn: pystan-2.2.0.1.tar.gz
+  url: https://pypi.python.org/packages/source/p/pystan/pystan-2.2.0.1.tar.gz
+  md5: 06f5bca8105c8fa96286183f57af1a61
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - pystan = pystan:main
+    #
+    # Would create an entry point called pystan that calls pystan.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - cython >=0.19
+    - numpy
+
+  run:
+    - python
+    - cython >=0.19
+    - numpy
+
+test:
+  # Python imports
+  imports:
+    - pystan
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/stan-dev/pystan
+  license: GNU General Public License v3 (GPLv3)
+  summary: 'Python interface to Stan, a package for Bayesian inference'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/scikits.sparse/build.sh
+++ b/scikits.sparse/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# We need libsuitesparse-dev for libcholmod.a
+ls /usr/lib/libcholmod.so > /dev/null ||
+  (echo "Install suitesparse via e.g. 'apt-get install libsuitesparse-dev'" ;
+   exit 1)
+
+$PYTHON setup.py install

--- a/scikits.sparse/container.yml
+++ b/scikits.sparse/container.yml
@@ -1,0 +1,21 @@
+# This Tank file will verify that scikits.sparse installs correctly. (It
+# installs suitesparse in the container as needed.)
+#
+# Run via: sudo -E tank container.yml
+
+containers:
+  - lucid-ci
+
+script:
+  - "wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O /tmp/Miniconda-3.5.5-Linux-x86_64.sh"
+  - "bash /tmp/Miniconda-3.5.5-Linux-x86_64.sh -b"
+  - "sudo apt-get install -y libsuitesparse-dev"
+    # For some reason, we need to install the dependencies manually :(
+  - "~/miniconda/bin/conda create --yes -n test python setuptools numpy scipy nose"
+    # Install the actuall package
+  - "~/miniconda/bin/conda install --yes -n test /tmp/scikits-sparse-0.2-np18py27_0.tar.bz2"
+    # Run the tests!
+  - "~/miniconda/envs/test/bin/nosetests scikits.sparse.test_cholmod"
+
+copy_into:
+  - "~/miniconda/conda-bld/linux-64/scikits-sparse-0.2-np18py27_0.tar.bz2": /tmp/scikits-sparse-0.2-np18py27_0.tar.bz2

--- a/scikits.sparse/meta.yaml
+++ b/scikits.sparse/meta.yaml
@@ -1,0 +1,50 @@
+# This provides scikits.sparse. That depends on libcholmod, which is installed
+# (on linux) as part of libsuitesparse-dev. You must have that library
+# installed in order to build or use this package!
+
+package:
+  name: scikits-sparse
+  version: "0.2"
+
+source:
+  fn: scikits.sparse-0.2.tar.gz
+  url: https://pypi.python.org/packages/source/s/scikits.sparse/scikits.sparse-0.2.tar.gz
+  md5: 0ee93ef2b1e5b9eb5c2a4e29dd06168a
+  patches:
+    # This patch makes sure the test data is included in the package.
+    - test_data.patch
+
+build:
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  number: 0
+
+requirements:
+  build:
+    - python
+    - cython
+    - setuptools
+    - numpy
+    - scipy
+
+  run:
+    - python
+    - setuptools
+    - numpy
+    - scipy
+
+test:
+  # Python imports
+  imports:
+    - scikits.sparse
+
+  requires:
+    - nose
+
+  commands:
+    - nosetests scikits.sparse.test_cholmod
+
+about:
+  home: http://code.google.com/p/scikits-sparse/
+  license:  GNU General Public License (GPL)
+  summary: 'Scikits sparse matrix package'

--- a/scikits.sparse/test_data.patch
+++ b/scikits.sparse/test_data.patch
@@ -1,0 +1,13 @@
+diff --git setup.py setup.py
+index 5766987..a4b2f9c 100644
+--- setup.py
++++ setup.py
+@@ -43,7 +43,7 @@ if __name__ == "__main__":
+           namespace_packages = ['scikits'],
+           packages = find_packages(),
+           package_data = {
+-              "": ["*.mtx.gz"],
++              "": ["test_data/*.mtx.gz"],
+               },
+           test_suite="nose.collector",
+           # Well, technically zipping the package will work, but since it's

--- a/seaborn/bld.bat
+++ b/seaborn/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/seaborn/build.sh
+++ b/seaborn/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/seaborn/meta.yaml
+++ b/seaborn/meta.yaml
@@ -1,0 +1,70 @@
+package:
+  name: seaborn
+  version: !!str 0.3.1
+
+source:
+  fn: seaborn-0.3.1.tar.gz
+  url: https://pypi.python.org/packages/source/s/seaborn/seaborn-0.3.1.tar.gz
+  md5: 7f39766a1dd2c9ddaacf7420d77208b2
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - seaborn = seaborn:main
+    #
+    # Would create an entry point called seaborn that calls seaborn.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pandas
+    - numpy
+    - scipy
+    - matplotlib
+
+  run:
+    - python
+    - pandas
+    - numpy
+    - scipy
+    - matplotlib
+
+test:
+  # Python imports
+  imports:
+    - seaborn
+    - seaborn.external
+    - seaborn.tests
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://stanford.edu/~mwaskom/software/seaborn/
+  license: BSD License
+  summary: 'Seaborn: statistical data visualization'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/simplejson/bld.bat
+++ b/simplejson/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/simplejson/build.sh
+++ b/simplejson/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/simplejson/meta.yaml
+++ b/simplejson/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: simplejson
+  version: !!str 3.5.2
+
+source:
+  fn: simplejson-3.5.2.tar.gz
+  url: https://pypi.python.org/packages/source/s/simplejson/simplejson-3.5.2.tar.gz
+  md5: 10ff73aa857b01472a51acb4848fcf8b
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - simplejson = simplejson:main
+    #
+    # Would create an entry point called simplejson that calls simplejson.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - simplejson
+    - simplejson.tests
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://github.com/simplejson/simplejson
+  license: Academic Free License (AFL) or MIT License
+  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/smmap/bld.bat
+++ b/smmap/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/smmap/build.sh
+++ b/smmap/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/smmap/meta.yaml
+++ b/smmap/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: smmap
+  version: !!str 0.8.2
+
+source:
+  fn: smmap-0.8.2.tar.gz
+  url: https://pypi.python.org/packages/source/s/smmap/smmap-0.8.2.tar.gz
+  md5: f5426b7626ddcf5e447253fae0396b0c
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - smmap = smmap:main
+    #
+    # Would create an entry point called smmap that calls smmap.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  # Python imports
+  imports:
+    - smmap
+    - smmap.test
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/Byron/smmap
+  license: BSD License
+  summary: 'A pure git implementation of a sliding window memory map manager'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/theano/bld.bat
+++ b/theano/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/theano/build.sh
+++ b/theano/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/theano/meta.yaml
+++ b/theano/meta.yaml
@@ -1,0 +1,96 @@
+package:
+  name: theano
+  version: !!str 0.6.0
+
+source:
+  fn: Theano-0.6.0.tar.gz
+  url: https://pypi.python.org/packages/source/T/Theano/Theano-0.6.0.tar.gz
+  md5: 44df6c476d8012290a2d5bb66611126a
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - theano = theano:main
+    #
+    # Would create an entry point called theano that calls theano.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy >=1.5.0
+    - scipy >=0.7.2
+
+  run:
+    - python
+    - numpy >=1.5.0
+    - scipy >=0.7.2
+
+test:
+  # Python imports
+  imports:
+    - theano
+    - theano.compat
+    - theano.compile
+    - theano.compile.sandbox
+    - theano.compile.tests
+    - theano.gof
+    - theano.gof.tests
+    - theano.misc
+    - theano.misc.tests
+    - theano.sandbox
+    - theano.sandbox.cuda
+    - theano.sandbox.cuda.tests
+    - theano.sandbox.gpuarray
+    - theano.sandbox.gpuarray.tests
+    - theano.sandbox.linalg
+    - theano.sandbox.linalg.tests
+    - theano.sandbox.scan_module
+    - theano.sandbox.scan_module.tests
+    - theano.scalar
+    - theano.scalar.tests
+    - theano.scan_module
+    - theano.scan_module.tests
+    - theano.sparse
+    - theano.sparse.sandbox
+    - theano.sparse.tests
+    - theano.tensor
+    - theano.tensor.deprecated
+    - theano.tensor.nnet
+    - theano.tensor.nnet.tests
+    - theano.tensor.signal
+    - theano.tensor.signal.tests
+    - theano.tensor.tests
+    - theano.tests
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://deeplearning.net/software/theano/
+  license: BSD License
+  summary: 'Optimizing compiler for evaluating mathematical expressions on CPUs and GPUs.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/xray/bld.bat
+++ b/xray/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/xray/build.sh
+++ b/xray/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/xray/meta.yaml
+++ b/xray/meta.yaml
@@ -1,0 +1,65 @@
+package:
+  name: xray
+  version: "v0.2.0alpha_4_g6c394b1"
+
+source:
+  fn: xray-6c394b14ecc04a53d804893060ed33cadfde688e.tar.gz
+  url: https://github.com/xray/xray/archive/6c394b14ecc04a53d804893060ed33cadfde688e.tar.gz
+  sha1: 9b50e44bf4a9015aea51efc18e3c6ad1da1c0990
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - xray = xray:main
+    #
+    # Would create an entry point called xray that calls xray.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy >=1.7
+    - pandas >=0.13.1
+
+  run:
+    - python
+    - numpy >=1.7
+    - pandas >=0.13.1
+
+test:
+  # Python imports
+  imports:
+    - xray
+    - xray.backends
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/xray/xray
+  license: Apache Software License
+  summary: 'Extended arrays for working with scientific datasets in Python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
We might have to look through these more carefully before merging, but these are all the external recipes we had in our climatology-research repo under projects/conda-product-eval/recipes/external.
