### PR TITLE
Relax numpy version requirements

### DIFF
--- a/bottleneck/meta.yaml
+++ b/bottleneck/meta.yaml
@@ -29,11 +29,11 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >=1.8
+    - numpy
 
   run:
     - python
-    - numpy >=1.8
+    - numpy
 
 test:
   # Python imports

--- a/theano/meta.yaml
+++ b/theano/meta.yaml
@@ -29,13 +29,13 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >=1.5.0
-    - scipy >=0.7.2
+    - numpy
+    - scipy
 
   run:
     - python
-    - numpy >=1.5.0
-    - scipy >=0.7.2
+    - numpy
+    - scipy
 
 test:
   # Python imports

--- a/xray/meta.yaml
+++ b/xray/meta.yaml
@@ -29,12 +29,12 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >=1.7
+    - numpy
     - pandas >=0.13.1
 
   run:
     - python
-    - numpy >=1.7
+    - numpy
     - pandas >=0.13.1
 
 test:


### PR DESCRIPTION
As of recent updates to conda-build, it doesn't like version specifications
like `numpy >=1.8`. You get the following error:

  Error: python and numpy versions should only be major.minor, like 2.7. Got >=1.8.

This PR should resolve this difficulty and allow these packages to be built.
