### PR TITLE
Add recipe for httpretty

### DIFF
--- a/httpretty/bld.bat
+++ b/httpretty/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/httpretty/build.sh
+++ b/httpretty/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/httpretty/meta.yaml
+++ b/httpretty/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: httpretty
+  version: !!str 0.8.3
+
+source:
+  fn: httpretty-0.8.3.tar.gz
+  url: https://pypi.python.org/packages/source/h/httpretty/httpretty-0.8.3.tar.gz
+  md5: 50b02560a49fe928c90c53a49791f621
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  #preserve_egg_dir: True
+  #entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - httpretty = httpretty:main
+    #
+    # Would create an entry point called httpretty that calls httpretty.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - urllib3 ==1.7.1
+
+  run:
+    - python
+    - urllib3 ==1.7.1
+
+test:
+  # Python imports
+  imports:
+    - httpretty
+
+  #commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://github.com/gabrielfalcao/httpretty
+  license:  MIT License
+  summary: 'HTTP client mock for Python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Added a conda recipe for `httpretty`. This recipe depends on version 1.7.1 of `urllib3`.
