### PR TITLE
Updating setup.py.patch and meta.yaml for moto 0.4.30

### DIFF
--- a/moto/meta.yaml
+++ b/moto/meta.yaml
@@ -39,6 +39,8 @@ requirements:
     - xmltodict
     - six
     - werkzeug
+    - pytz
+    - python-dateutil
 
   run:
     - python
@@ -50,6 +52,8 @@ requirements:
     - xmltodict
     - six
     - werkzeug
+    - pytz
+    - python-dateutil
 
 test:
   # Python imports

--- a/moto/setup.py.patch
+++ b/moto/setup.py.patch
@@ -1,9 +1,9 @@
---- setup.py	2016-06-29 11:05:22.000000000 -0500
-+++ mysetup.py	2016-06-29 11:09:14.000000000 -0500
-@@ -6,7 +6,7 @@
-     "Jinja2",
+--- a/setup.py
++++ b/setup.py
+@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
+ install_requires = [
+     "Jinja2>=2.8",
      "boto>=2.36.0",
-     "flask",
 -    "httpretty==0.8.10",
 +    "httpretty>=0.8.10",
      "requests",


### PR DESCRIPTION
I've added pytz and python-dateutil to the meta.yaml
dependencies.

Apologies for the multiple PRs.